### PR TITLE
Update `--require`

### DIFF
--- a/packages/supertape/lib/cli.js
+++ b/packages/supertape/lib/cli.js
@@ -1,15 +1,13 @@
 'use strict';
 
-const {resolve: resolvePath} = require('path');
 const {once} = require('events');
-const {pathToFileURL} = require('url');
 
 const yargsParser = require('yargs-parser');
 const glob = require('glob');
 const fullstore = require('fullstore');
 const tryToCatch = require('try-to-catch');
 const keypress = require('@putout/cli-keypress');
-const {simpleImport} = require('./simple-import');
+const {importOrRequire} = require('./import-or-require');
 
 const supertape = require('..');
 const {
@@ -176,11 +174,8 @@ async function cli({argv, cwd, stdout, isStop}) {
     const promises = [];
     const files = removeDuplicates(allFiles);
     
-    for (const file of files) {
-        // always resolve before import for windows
-        const resolved = pathToFileURL(resolvePath(cwd, file));
-        promises.push(simpleImport(resolved));
-    }
+    for (const file of files)
+        promises.push(importOrRequire(cwd, file));
     
     filesCount(files.length);
     

--- a/packages/supertape/lib/import-or-require.js
+++ b/packages/supertape/lib/import-or-require.js
@@ -6,7 +6,7 @@ const {pathToFileURL} = require('url');
 module.exports.importOrRequire = (cwd, file) => {
     const resolved = resolvePath(cwd, file);
     
-    if (extnamePath(file).endsWith('js')) {
+    if (extnamePath(file).includes('js')) {
         // always resolve before import for windows
         import(pathToFileURL(resolved));
     } else {

--- a/packages/supertape/lib/import-or-require.js
+++ b/packages/supertape/lib/import-or-require.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const {resolve: resolvePath, extname: extnamePath} = require('path');
+const {pathToFileURL} = require('url');
+
+module.exports.importOrRequire = (cwd, file) => {
+    const resolved = resolvePath(cwd, file);
+    
+    if (extnamePath(file).endsWith('js')) {
+        // always resolve before import for windows
+        import(pathToFileURL(resolved));
+    } else {
+        require(resolved);
+    }
+};
+


### PR DESCRIPTION
Implements and closes #4 using a slightly modified `import-or-require.js` from [`tape`](https://github.com/substack/tape/blob/v5.6.0/bin/import-or-require.js). Adds [`get-package-type`](https://www.npmjs.com/package/get-package-type) as a dependency[^1].

Modifies the `cli()` function in `cli.js` for module resolution:

```js
for (const module of args.require) {
    const resolved = nodeResolve(module, {basedir: cwd});
    importOrRequire(resolved);
}

// ...

for (const file of files) {
    // always resolve before import for windows
    const resolved = resolvePath(cwd, file);
    promises.push(importOrRequire(resolved));
}
```

Currently:

https://github.com/coderaiser/supertape/blob/f37329cc32121d268dd259e6bfccb32967422527/packages/supertape/lib/cli.js#L145-L146

https://github.com/coderaiser/supertape/blob/f37329cc32121d268dd259e6bfccb32967422527/packages/supertape/lib/cli.js#L179-L183

----

This PR does not remove `simple-import.js`.

[^1]: `tape` currently has `resolve` set to [`^2.0.0-next.3`](https://github.com/browserify/resolve/tree/v2.0.0-next.3) (vs. `^1.17.0` in Supertape). Haven't looked into the changes between the two versions, but `--require` seems to function correctly with both.