### PR TITLE
Reorganize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 📼 **Supertape** is a fast, minimal test runner with the soul of **tape**. It's designed to be as compatible as possible with **tape** while still having some key improvements, such as:
 
-- out-of-the-box [ES6 module](https://nodejs.org/api/esm.html) support (take a look at [mock-import](https://github.com/coderaiser/mock-import) for mocking and 🎩[ESCover](https://github.com/coderaiser/escover) for coverage)
+- out-of-the-box [EcmaScript Modules](https://nodejs.org/api/esm.html) support (take a look at [mock-import](https://github.com/coderaiser/mock-import) for mocking and 🎩[ESCover](https://github.com/coderaiser/escover) for coverage)
 - a number of [built-in pretty output formatters](#formatting)
 - easy [configuration](#list-of-options)
 - the ability to [extend](#extending)

--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ Certain options, such as [`SUPERTAPE_TIMEOUT`](#supertape_timeout) can only be s
 
 Controls the time (in milliseconds) that a test is allowed to run for before timing out. By default, tests time out after 3 seconds (or `3000` ms).
 
+#### `SUPERTAPE_CHECK_SKIPED`
+
+If specified, tells 📼 **Supertape** to check the number of skipped test files. Exits with status code [`SKIPED`](#-exit-codes).
+
+*Note: yes, `skiped` is a typo.*
+
 #### `SUPERTAPE_PROGRESS_BAR_COLOR`
 
 If using the `progress-bar` formatter, sets the color of the progress bar itself. Can either be a hex color or a valid [**chalk**](https://github.com/chalk/chalk#colors) color. Defaults to ![#f9d472](https://via.placeholder.com/15/f9d472/f9d472.png) `#f9d472`.
@@ -557,6 +563,32 @@ To simplify the core of 📼 **Supertape**, other operators are maintained in se
 
 [OperatorStubNPMBadge]: https://img.shields.io/npm/v/@supertape/operator-stub.svg?maxAge=86400
 [OperatorStubNPMLink]: https://www.npmjs.com/package/@supertape/operator-stub
+
+## 🚪 Exit Codes
+
+📼**Supertape** can have one of the following [exit codes](https://github.com/coderaiser/supertape/blob/master/packages/supertape/lib/exit-codes.js) to denote its status:
+
+| Code | Name | Description |
+|------|------|-----------------|
+| 0    | `OK` | no errors found |
+| 1    | `FAIL` | test failed |
+| 2    | `WAS_STOP` | test was halted by user |
+| 3    | `UNHANDLED`| unhandled exception occurred |
+| 4    | `INVALID_OPTION`| wrong option provided |
+| 5    | `SKIPED` | works only with [`SUPERTAPE_CHECK_SKIPED`](#supertape_check_skiped) when skiped files 1 and more |
+
+```js
+import {SKIPED} from 'supertape/exit-codes';
+
+const env = {
+    ESCOVER_SUCCESS_EXIT_CODE: SKIPED,
+    SUPERTAPE_CHECK_SKIPED: 1,
+};
+
+export default {
+    test: () => [env, `escover tape 'test/**/*.js' 'lib/**/*.spec.js'`],
+};
+```
 
 ## 🐊 **Putout**
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ For a list of all built-in assertions, see [Operators](#operators).
 
 ## Installation
 
-```plain
 npm i supertape -D
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@
 
 [**Tape**](https://github.com/substack/tape)-inspired [`TAP`](https://testanything.org/)-compatible simplest high speed test runner with superpowers.
 
-----
-
 📼 **Supertape** is a fast, minimal test runner with the soul of **tape**. It's designed to be as compatible as possible with **tape** while still having some key improvements, such as:
 
 - out-of-the-box [ES6 module](https://nodejs.org/api/esm.html) support (take a look at [mock-import](https://github.com/coderaiser/mock-import) for mocking and 🎩[ESCover](https://github.com/coderaiser/escover) for coverage)

--- a/README.md
+++ b/README.md
@@ -14,15 +14,18 @@
 
 [**Tape**](https://github.com/substack/tape)-inspired [`TAP`](https://testanything.org/)-compatible simplest high speed test runner with superpowers.
 
+----
+
 📼 **Supertape** is a fast, minimal test runner with the soul of **tape**. It's designed to be as compatible as possible with **tape** while still having some key improvements, such as:
 
-- the ability to work with [ESM Modules](https://nodejs.org/api/esm.html) (take a look at [mock-import](https://github.com/coderaiser/mock-import) for mocking and 🎩[ESCover](https://github.com/coderaiser/escover) for coverage)
-- a number of [built-in pretty output formatters](#formatters)
-- the ability to [extend](#testextendextensions)
+- out-of-the-box [ES6 module](https://nodejs.org/api/esm.html) support (take a look at [mock-import](https://github.com/coderaiser/mock-import) for mocking and 🎩[ESCover](https://github.com/coderaiser/escover) for coverage)
+- a number of [built-in pretty output formatters](#formatting)
+- easy [configuration](#list-of-options)
+- the ability to [extend](#extending)
 - showing colored diff when using the [`t.equal()`](#tequalresult-any-expected-any-message-string) and [`t.deepEqual()`](#tdeepequalresult-any-expected-any-message-string) assertion operators
 - detailed stack traces for `async` functions
-- multiple [`test.only`'s](#testonlyname-cb)
-- [smart timeouts](#environment-variables) for long running tests 🏃‍♂️
+- multiple [`test.only`s](#testonlymessage-string-fn-t-test--void-options-testoptions)
+- [smart timeouts](#supertape_timeout) for long running tests 🏃‍♂️
 - more natural assertions: `expected, result` -> `result, expected`:
 
   ```js
@@ -32,21 +35,64 @@
 📼 **Supertape** doesn't contain:
 
 - assertion aliases, making the available operators far more concise
-- `es3 code` and lot's of [ponyfills](https://github.com/sindresorhus/ponyfill#how-are-ponyfills-better-than-polyfills)
+- `ES3 code` and lots of [ponyfills](https://github.com/sindresorhus/ponyfill#how-are-ponyfills-better-than-polyfills)
 - `t.throws()`, `t.doesNotThrow()` - use [**tryCatch**](https://github.com/coderaiser/try-catch) or [**tryToCatch**](https://github.com/coderaiser/try-to-catch) with [`t.equal()`](#tequalresult-any-expected-any-message-string) instead
 - [`t.plan()`](https://github.com/substack/tape#tplann)
 
 For a list of all built-in assertions, see [Operators](#operators).
 
-## Install
+## Installation
 
-```
+```plain
 npm i supertape -D
 ```
 
-## Usage
+## Example
 
+```js
+// test.js
+const test = require('supertape');
+
+test('hello: world', (t) => {
+    t.pass('hello, world!');
+    t.end();
+});
 ```
+
+Output:
+
+```plain
+$ npx supertape test.js
+TAP version 13
+
+1..1
+# tests 1
+# pass 1
+
+# ✅ ok
+```
+
+## Usage and Configuration
+
+Tests can be run either through the `supertape` CLI (or optionally through `node`/`ts-node`). [Options](#list-of-options) can be specified via the command line, through environment variables, or in individual test files.
+
+### Command Line
+
+📼 **Supertape** provides a CLI that supports running both `CJS` and `ESM` tests:
+
+```sh
+$ [npx] supertape [options] [path/glob]
+```
+
+If a glob is specified instead of a single file path (e.g. `tests/*.js`), all of the test results are outputted together.
+
+#### Command Line Flags:
+
+#### `--help` (alias: `-h`)
+
+Displays a help prompt with usage information and exits:
+
+```plain
 Usage: supertape [options] [path]
 Options
    -h, --help                  display this help and exit
@@ -58,152 +104,388 @@ Options
    --no-check-duplicates       do not check messages for duplicates
 ```
 
-## Environment variables
+#### `--version` (alias: `-v`)
 
-- `SUPERTAPE_TIMEOUT` - timeout for long running processes;
-- `SUPERTAPE_CHECK_DUPLICATES` - toggle check duplicates;
-- `SUPERTAPE_CHECK_SCOPES` - check that test message has a scope: `scope: subject`;
-- `SUPERTAPE_CHECK_ASSERTIONS_COUNT` - check that assertion count is no more then 1;
+Outputs version information and exits.
+
+#### `--format [format]` (alias: `-f`)
+
+Sets a specific [format](#formatting) for outputting test results. When using the CLI, this option must be set to change the format used. Defaults to `progress-bar`.
+
+#### `--require [module]` (alias: `-r`)
+
+Loads a given module before running all tests. Can be used to perform [JIT transpilation](https://github.com/substack/tape#preloading-modules).
+
+#### `--no-check-duplicates`
+
+Tells 📼 **Supertape** not to check test messages for duplicates. By default, messages are expected to be unique. (See: [Duplicate Test Messages](#duplicate-test-messages))
+
+#### `--no-check-assertions-count`
+
+Tells 📼 **Supertape** not to check the number of assertions per test. By default, only one assertion is allowed. (See: [Assertions Per Test](#assertions-per-test))
+
+#### `--no-check-scopes`
+
+Tells 📼 **Supertape** not to check test messages for proper scoping (i.e. in the form `'scope: message'`). By default, messages are expected to be scoped. (See: [Test Message Scoping](#test-message-scoping))
+
+### Environment Variables
+
+The 📼 **Supertape** CLI also supports setting some options through environment variables:
+
+```sh
+$ SUPERTAPE_TIMEOUT=5000 supertape tests/*.js
+```
+
+Certain options, such as [`SUPERTAPE_TIMEOUT`](#supertape_timeout) can only be set in this way.
+
+#### Environment Variable Only Options:
+
+#### `SUPERTAPE_TIMEOUT`
+
+Controls the time (in milliseconds) that a test is allowed to run for before timing out. By default, tests time out after 3 seconds (or `3000` ms).
+
+#### `SUPERTAPE_PROGRESS_BAR_COLOR`
+
+If using the `progress-bar` formatter, sets the color of the progress bar itself. Can either be a hex color or a valid [**chalk**](https://github.com/chalk/chalk#colors) color. Defaults to ![#f9d472](https://via.placeholder.com/15/f9d472/f9d472.png) `#f9d472`.
+
+#### `SUPERTAPE_PROGRESS_BAR_MIN`
+
+If using the `progress-bar` formatter, sets the minimum number of tests to run before showing the progress bar. Defaults to `100`. Set to `0` to always show.
+
+#### `SUPERTAPE_PROGRESS_BAR_STACK`
+
+If using the `progress-bar` formatter, sets a flag to show or hide the error stack when an assertion fails. Defaults to `1` *(show)*. Set to `0` to hide.
+
+#### Other Options:
+
+#### `SUPERTAPE_CHECK_DUPLICATES`
+
+Set to `0` to tell 📼 **Supertape** not to check test messages for duplicates. By default, messages are expected to be unique. (See: [Duplicate Test Messages](#duplicate-test-messages))
+
+#### `SUPERTAPE_CHECK_ASSERTIONS_COUNT`
+
+Set to `0` to tell 📼 **Supertape** not to check the number of assertions per test. By default, only one assertion is allowed. (See: [Assertions Per Test](#assertions-per-test))
+
+#### `SUPERTAPE_CHECK_SCOPES`
+
+Set to `0` to tell 📼 **Supertape** not to check test messages for proper scoping (i.e. in the form `'scope: message'`). By default, messages are expected to be scoped. (See: [Test Message Scoping](#test-message-scoping))
+
+### `node` and `ts-node`
+
+While the preferred way to use 📼 **Supertape** is via the CLI, any test file (`.js` or `.ts`) requiring/importing 📼 **Supertape** can be invoked through `node` or `ts-node`, respectively:
 
 ```js
-test('tape: error', (t) => {
-    t.equal(error.code, 'ENOENT');
+// test.js or test.ts
+import test from 'supertape';
+
+test('test: from (ts-)node', (t) => {
+    t.pass('hello, world!');
     t.end();
 });
 ```
 
-## 🤷 How to migrate from **tape**?
+```bash
+$ node test.js
+# OR
+$ ts-node test.ts
+```
 
-> 🐊 + 📼 = ❤️
+### Formatting
 
-You can convert your codebase from **tape** to 📼**Supertape** with help of 🐊[**Putout**](https://github.com/coderaiser/putout), which has built-in [**@putout/plugin-tape**](https://github.com/coderaiser/putout/tree/master/packages/plugin-tape#readme),
-with a lot of rules that helps to write and maintain tests of the highest possible quality.
+#### Built-In Formatters
 
-Here is [result example](https://github.com/coderaiser/cloudcmd/commit/74d56f795d22e98937dce0641ee3c7514a79e9e6).
+📼 **Supertape** provides a few different output formats beyond the regular `TAP` format. When using the [`supertape` CLI](#command-line), the `progress-bar` formatter is used by default. In all other cases, the default is the `tap` format.
 
-## **ESLint** rules
+The format used can be changed with:
 
-[**eslint-plugin-putout**](https://github.com/coderaiser/putout/tree/master/packages/eslint-plugin-putout#-supertape) has a couple rules for 📼**Supertape**:
+- the [`--format [format]`](#--format-format-alias--f) command line flag
+- the [`options.format`](#format-string) option passed to a test
 
-- ✅ [`remove-newline-before-t-end`](https://github.com/coderaiser/putout/tree/master/packages/eslint-plugin-putout/lib/tape-remove-newline-before-t-end#readme)
-- ✅ [`add-newline-before-assertion`](https://github.com/coderaiser/putout/tree/master/packages/eslint-plugin-putout/lib/tape-add-newline-before-assertion#readme)
-- ✅ [`add-newline-between-tests`](https://github.com/coderaiser/putout/tree/master/packages/eslint-plugin-putout/lib/tape-add-newline-between-tests#readme)
+While each formatter is maintained in a separate package, they are included when downloading 📼 **Supertape**. The following is a list of such packages:
 
-## Validation checks
+|Package|Version|
+|-------|-------|
+| [`@supertape/formatter-tap`](/packages/formatter-tap)                   | [![npm][FTapNPMBadge]][FTapNPMLink]     |
+| [`@supertape/formatter-fail`](/packages/formatter-fail)                 | [![npm][FFailNPMBadge]][FFailNPMLink]   |
+| [`@supertape/formatter-progress-bar`](/packages/formatter-progress-bar) | [![npm][FProgNPMBadge]][FProgNPMLink]   |
+| [`@supertape/formatter-json-lines`](/packages/formatter-json-lines)     | [![npm][FJsonNPMBadge]][FJsonNPMLink]   |
+| [`@supertape/formatter-short`](/packages/formatter-short)               | [![npm][FShortNPMBadge]][FShortNPMLink] |
 
-To up the quality of your tests even higher, 📼**Supertape** has built-in checks.
-When test not passes validation it marked as a new failed test.
+[FTapNPMBadge]: https://img.shields.io/npm/v/@supertape/formatter-tap.svg?maxAge=86400
+[FTapNPMLink]: https://www.npmjs.com/package/@supertape/formatter-tap
+[FFailNPMBadge]: https://img.shields.io/npm/v/@supertape/formatter-fail.svg?maxAge=86400
+[FFailNPMLink]: https://www.npmjs.com/package/@supertape/formatter-fail
+[FProgNPMBadge]: https://img.shields.io/npm/v/@supertape/formatter-progress-bar.svg?maxAge=86400
+[FProgNPMLink]: https://www.npmjs.com/package/@supertape/formatter-progress-bar
+[FJsonNPMBadge]: https://img.shields.io/npm/v/@supertape/formatter-json-lines.svg?maxAge=86400
+[FJsonNPMLink]: https://www.npmjs.com/package/@supertape/formatter-json-lines
+[FShortNPMBadge]: https://img.shields.io/npm/v/@supertape/formatter-short.svg?maxAge=86400
+[FShortNPMLink]: https://www.npmjs.com/package/@supertape/formatter-short
 
-### Single `t.end()`
+#### Using Other `TAP` Reporters
 
-`t.end()` must not be used more than once. This check cannot be disabled
-and has auto fixable rule 🐊[`remove-useless-t-end`](https://github.com/coderaiser/putout/blob/master/packages/plugin-tape/README.md#remove-useless-t-end).
+If you'd like to use another output format instead of the built-in formatters, such as [**`tap-min`**](https://www.npmjs.com/package/tap-min), use the `format: 'tap'` option and pipe the output to the reporter of your choice:
 
-#### ❌ Example of incorrect code
+```bash
+$ supertape tests/*.js -f tap | tap-min
+```
+
+### Extending
+
+📼 **Supertape** maintains a minimal number of core assertion operators, leaving out aliases and things like `t.throws()`. Custom extension operators can either be added through the [`test.extend(extensions)`](#testextendextensions) function.
+
+The `extend()` function takes a dictionary of functions that each take an object of built-in operators as input, and return an operator function with any number of arguments. The return value of the `extend()` function is a `test` object with the custom operators added to it. For example, adding a `transform` operator:
+
+```js
+const {extend} = require('supertape');
+
+const test = extend({
+    transform: (t) => (a, b, message = 'should transform') => {
+        const {is, output} = t.equal(a + 1, b - 1);
+        return {
+            is,
+            output,
+            message,
+        };
+    },
+});
+
+test('test: transform', (t) => {
+    t.transform(1, 3);
+    t.end();
+});
+```
+
+Extension operators can also be included in the [`options.extensions`](#extensions-customoperator) object in calls to `test()`.
+
+## List of Options
+
+Individual tests can take an optional `options` parameter for setting configuration values:
+
+```js
+const test = require('supertape');
+
+test('no scope', (t) => {
+    t.pass('this test has two assertions');
+    t.pass('this test has no message scope');
+    t.end();
+}, {
+    checkAssertionsCount: false,
+    checkScopes: false,
+});
+```
+
+Instead of setting the same options multiple times, a custom wrapper can be used that sets common options:
+
+```js
+// _supertape.js
+import {test as _test} from 'supertape';
+
+export const test = (message, fn) => _test(message, fn, {
+    checkAssertionsCount: false,
+});
+```
+
+```js
+// test.js
+import test from '_supertape';
+
+test('test: wrapper', (t) => {
+    t.pass('using a wrapper');
+    t.pass('with two assetions');
+    t.end();
+});
+```
+
+### Options
+
+#### `skip: boolean`
+
+Whether or not to skip a test. Defaults to `false`.
+
+#### `only: boolean`
+
+Whether or not to mark a test as the only one run by the process. Defaults to `false`.
+
+#### `extensions: CustomOperator`
+
+Custom extension operators to use in tests. Defaults to `{}`. (See: [Extending](#extending))
+
+#### `quiet: boolean`
+
+Whether or not to not report test results. Defaults to `false`.
+
+#### `format: string`
+
+Which output format to use for the test results. The [built-in `tap` formatters](#formatting) are `tap`, `fail`, `progress-bar`, `json-lines`, and `short`. Defaults to `tap`.
+
+When using the CLI, the default formatter is `progress-bar`. This can only be overridden using the `--format [format]` flag.
+
+#### `run: boolean`
+
+Whether or not to run a test. Defaults to `true`.
+
+#### `checkDuplicates: boolean`
+
+Whether or not to check test messages for duplicates. 📼 **Supertape** expects each message to be unique. Defaults to `true`. (See: [Duplicate Test Messages](#duplicate-test-messages))
+
+#### `checkAssertionsCount: boolean`
+
+Whether or not to check the number of assertions per test. 📼 **Supertape** expects each test to have only one assertion. Defaults to `true`. (See: [Assertions Per Test](#assertions-per-test))
+
+#### `checkScopes: boolean`
+
+Whether or not to check that test messages are scoped (i.e. in the form `'scope: message'`). 📼 **Supertape** expects each test message to be scoped. (See: [Test Message Scoping](#test-message-scoping))
+
+## Validation
+
+📼 **Supertape** has a number of built-in validation checks to ensure that your tests are of the highest possible quality. A test will fail if it does not pass these checks. Certain checks can be disabled. (See: [Configuration](#usage-and-configuration))
+
+### Single Call to `t.end()`
+
+Each test must call the [`t.end()`](#tend) operator to denote that it has finished. Only one call to `t.end()` is allowed, and no assertions are allowed after it.
+
+This check cannot be disabled. In addition, 🐊 **Putout** has a rule 🐊 [`remove-useless-t-end`][PutoutTEnd] for ensuring it is only called once. (See: [Putout](#-putout))
+
+[PutoutTEnd]: https://github.com/coderaiser/putout/blob/master/packages/plugin-tape/README.md#remove-useless-t-end
+
+#### ❌ Example of Incorrect Code:
 
 ```js
 test('hello: world', (t) => {
     t.end();
     t.end();
+    t.pass('hello, world!');
 });
 ```
 
-#### ✅ Example of correct code
+#### ✅ Example of Correct Code:
 
 ```js
 test('hello: world', (t) => {
+    t.pass('hello, world!');
     t.end();
 });
 ```
 
-### Check duplicates
+### Duplicate Test Messages
 
-Check for duplicates in test messages. Can be disabled with:
+📼 **Supertape** expects all test messages to be unique. This check can be disabled with:
 
-- passing `--no-check-duplicates` command line flag;
-- setting `SUPERTAPE_CHECK_DUPLICATES=0` env variable;
+- the [`--no-check-duplicates`](#--no-check-duplicates) command line flag
+- the [`SUPERTAPE_CHECK_DUPLICATES`](#supertape_check_duplicates) environment variable (set to `0`)
+- the [`checkDuplicates`](#checkduplicates-boolean) test option (set to `true`)
 
-#### ❌ Example of incorrect code
+#### ❌ Example of Incorrect Code:
 
 ```js
 test('hello: world', (t) => {
-    t.equal(1, 1);
+    t.pass('hello one!');
     t.end();
 });
-```
 
-```js
 test('hello: world', (t) => {
-    t.equal(2, 1);
+    t.pass('hello two!');
     t.end();
 });
 ```
 
-### Check scopes
+### Assertions Per Test
 
-Check that test message are divided on groups by colons. Can be disabled with:
+📼 **Supertape** expects that each test contains exactly one assertion. This check can be disabled with:
 
-- passing `--no-check-scopes` command line flag;
-- setting `SUPERTAPE_CHECK_SCOPES=0` env variable;
+- the [`--no-check-assertions-count`](#--no-check-assertions-count) command line flag
+- the [`SUPERTAPE_CHECK_ASSERTIONS_COUNT`](#supertape_check_assertions_count) environment variable (set to `0`)
+- the [`checkAssertionsCount`](#checkassertionscount-boolean) test option (set to `true`)
 
-#### ❌ Example of incorrect code
-
-```js
-test('hello', (t) => {
-    t.equal(1, 1);
-    t.end();
-});
-```
-
-#### ✅ Example of correct code
+#### ❌ Example of Incorrect Code:
 
 ```js
-test('hello: world', (t) => {
-    t.equal(1, 1);
-    t.end();
-});
-```
-
-### Check assertions count
-
-Check that test contains exactly one assertion. Can be disabled with:
-
-- passing `--no-check-assertions-count` command line flag;
-- setting `SUPERTAPE_CHECK_ASSERTIONS_COUNT=0` env variable;
-
-#### ❌ Example of incorrect code
-
-```js
-test('hello: no assertion', (t) => {
+test('test: no assertion', (t) => {
     t.end();
 });
 
-test('hello: more then one assertion', (t) => {
+test('test: more than one assertion', (t) => {
     t.equal(1, 1);
     t.equal(2, 2);
     t.end();
 });
 ```
 
-#### ✅ Example of correct code
+#### ✅ Example of Correct Code:
 
 ```js
-test('hello: one', (t) => {
+test('test: one', (t) => {
     t.equal(1, 1);
     t.end();
 });
 
-test('hello: two', (t) => {
+test('test: two', (t) => {
     t.equal(2, 2);
     t.end();
 });
 ```
+
+### Test Message Scoping
+
+📼 **Supertape** expects that each test message be scoped in the form `'scope: message'`. This check can be disabled with:
+
+- the [`--no-check-scopes`](#--no-check-scopes) command line flag
+- the [`SUPERTAPE_CHECK_SCOPES`](#supertape_check_scopes) environment variable (set to `0`)
+- the [`checkScopes`](#checkscopes-boolean) test option (set to `true`)
+
+#### ❌ Example of Incorrect Code:
+
+```js
+test('test no scope', (t) => {
+    t.pass('hello, world!');
+    t.end();
+});
+```
+
+#### ✅ Example of Correct Code:
+
+```js
+test('test: scope', (t) => {
+    t.pass('hello, world!');
+    t.end();
+});
+```
+
+## API
+
+#### `test(message: string, fn: (t: Test) => void, options?: TestOptions)`
+
+The core test function. Generates a new test with a [scoped `message`](#test-message-scoping). The test object `t` provides all [built-in assertion operators](#operators) as well as any [extension operators](#extending) that have been added. Tests execute serially. By default, 📼 **Supertape** expects each test to have a [unique message](#duplicate-test-messages) and a [single assertion](#assertions-per-test):
+
+```js
+const test = require('supertape');
+
+test('hello: world', (t) => {
+    t.pass('hello, world!');
+    t.end();
+});
+```
+
+[Options](#list-of-options) can be specified on a per-test basis as well.
+
+#### `test.skip(message: string, fn: (t: Test) => void, options?: TestOptions)`
+
+Generates a new test that will be skipped over by setting [`options.skip`](#skip-boolean) to `true`.
+
+#### `test.only(message: string, fn: (t: Test) => void, options?: TestOptions)`
+
+Generates a new test that will be the only test run for the entire process, ignoring all other tests, by setting [`options.only`](#only-boolean) to `true`.
+
+#### `test.extend(extensions: CustomOperators)`
+
+Generates a new test function that includes the specified custom extension operators. For more information, see [Extending](#extending).
 
 ## Operators
 
-The assertion methods of 📼 **Supertape** are heavily influenced by [**tape**](https://github.com/substack/tape). However, to keep a minimal core of assertions, there are no aliases and some superfluous operators have been removed (such as `t.throws()`).
+The assertion operators of 📼 **Supertape** are heavily influenced by [**tape**](https://github.com/substack/tape). However, to keep a minimal core of assertions, there are no aliases and some superfluous operators have been removed (such as `t.throws()`).
 
-The following is a list of the base methods maintained by 📼 **Supertape**. Others, such as assertions for stubbing, are maintained in [special operators](#special-operators). To add custom assertion operators, see [Extending](#testextendextensions).
+The following is a list of the base methods maintained by 📼 **Supertape**. Other built-in operators, such as assertions for stubbing, are maintained in [separate packages](#other-built-in-operators). To add custom assertion operators, see [Extending](#extending).
 
 ### Core Operators
 
@@ -251,7 +533,7 @@ Generates a failing assertion with `message` as a description.
 
 #### `t.end()`
 
-Declares the end of a test explicitly. Must be called exactly once per test. (See: [Single Call to `t.end()`](#single-tend)
+Declares the end of a test explicitly. Must be called exactly once per test. (See: [Single Call to `t.end()`](#single-call-to-tend))
 
 #### `t.match(result: string, pattern: string | RegExp, message?: string)`
 
@@ -263,130 +545,36 @@ Asserts that `result` does not match the regex `pattern`. If `pattern` is not a 
 
 #### `t.comment(message: string)`
 
-Print a message without breaking the `TAP` output. Useful when using a `tap`-reporter such as `tap-colorize`, where the output is buffered and `console.log()` will print in incorrect order vis-a-vis `TAP` output.
+Prints a message without breaking the `TAP` output. Useful when using a `tap`-reporter such as `tap-colorize`, where the output is buffered and `console.log()` will print in incorrect order vis-a-vis `TAP` output.
 
-### Special Operators
+### Other Built-In Operators
 
 To simplify the core of 📼 **Supertape**, other operators are maintained in separate packages. The following is a list of all such packages:
 
-Here is a list of built-int operators:
+|Package|Version|
+|-------|-------|
+| [`@supertape/operator-stub`](/packages/operator-stub) | [![npm][OperatorStubNPMBadge]][OperatorStubNPMLink] |
 
-| Package | Version |
-|--------|-------|
-| [`@supertape/operator-stub`](/packages/operator-stub) | [![npm](https://img.shields.io/npm/v/@supertape/operator-stub.svg?maxAge=86400)](https://www.npmjs.com/package/@supertape/operator-stub) |
+[OperatorStubNPMBadge]: https://img.shields.io/npm/v/@supertape/operator-stub.svg?maxAge=86400
+[OperatorStubNPMLink]: https://www.npmjs.com/package/@supertape/operator-stub
 
-## Formatters
+## 🐊 **Putout**
 
-There is a list of built-int `formatters` to customize output:
+📼 **Supertape** goes well with 🐊 [**Putout**](https://github.com/coderaiser/putout), which has a number of rules for linting and generating high quality tests.
 
-| Package | Version |
-|--------|-------|
-| [`@supertape/formatter-tap`](/packages/formatter-tap) | [![npm](https://img.shields.io/npm/v/@supertape/formatter-tap.svg?maxAge=86400)](https://www.npmjs.com/package/@supertape/formatter-tap) |
-| [`@supertape/formatter-fail`](/packages/formatter-fail) | [![npm](https://img.shields.io/npm/v/@supertape/formatter-fail.svg?maxAge=86400)](https://www.npmjs.com/package/@supertape/formatter-fail) |
-| [`@supertape/formatter-short`](/packages/formatter-short) | [![npm](https://img.shields.io/npm/v/@supertape/formatter-short.svg?maxAge=86400)](https://www.npmjs.com/package/@supertape/formatter-short) |
-| [`@supertape/formatter-progress-bar`](/packages/formatter-progress-bar) | [![npm](https://img.shields.io/npm/v/@supertape/formatter-progress-bar.svg?maxAge=86400)](https://www.npmjs.com/package/@supertape/formatter-progress-bar) |
-| [`@supertape/formatter-json-lines`](/packages/formatter-json-lines) | [![npm](https://img.shields.io/npm/v/@supertape/formatter-json-lines.svg?maxAge=86400)](https://www.npmjs.com/package/@supertape/formatter-json-lines) |
+### Migrating From **tape**
 
-## API
+> 🐊 + 📼 = ❤️
 
-### Methods
+You can easily convert your tests from **tape** to 📼 **Supertape** using 🐊 **Putout's** built-in [`@putout/plugin-tape`][PutoutPluginTape]. For a conversion example, check out [this output][PutoutExample].
 
-The assertion methods of 📼**Supertape** are heavily influenced by [**tape**](https://github.com/substack/tape).
+[PutoutPluginTape]: https://github.com/coderaiser/putout/tree/master/packages/plugin-tape#readme
+[PutoutExample]: https://github.com/coderaiser/cloudcmd/commit/74d56f795d22e98937dce0641ee3c7514a79e9e6
 
-```js
-const test = require('supertape');
-const {sum} = require('./calc.js');
+### **ESLint** Rules
 
-test('calc: sum', (t) => {
-    const result = sum(1, 2);
-    const expected = 3;
-    
-    t.equal(result, expected);
-    t.end();
-});
-```
+🐊 **Putout** also provides some **ESLint** rules for 📼 **Supertape** to help ensure high quality tests:
 
-or in `ESM`:
-
-```js
-import {test} from 'supertape';
-import {sum} from './calc.js';
-
-test('calc: sum', (t) => {
-    const result = sum(1, 2);
-    const expected = 3;
-    
-    t.equal(result, expected);
-    t.end();
-});
-```
-
-## test(name, cb)
-
-Create a new test with `name` string.
-`cb(t)` fires with the new test object `t` once all preceding tests have
-finished. Tests execute serially.
-
-## test.only(name, cb)
-
-Like `test(name, cb)` except if you use `.only` this is the only test case
-that will run for the entire process, all other test cases using `tape` will
-be ignored.
-
-## test.skip(name, cb)
-
-Generate a new test that will be skipped over.
-
-## test.extend(extensions)
-
-Extend base assertions with more:
-
-```js
-const {extend} = require('supertape');
-const test = extend({
-    transform: (operator) => (a, b, message = 'should transform') => {
-        const {is, output} = operator.equal(a + 1, b - 1);
-        return {
-            is,
-            output,
-        };
-    },
-});
-
-test('assertion', (t) => {
-    t.transform(1, 3);
-    t.end();
-});
-```
-
-## Example
-
-```js
-const test = require('supertape');
-
-test('lib: arguments', async (t) => {
-    throw Error('hello');
-    // will call t.fail with an error
-    // will call t.end
-});
-
-test('lib: diff', (t) => {
-    t.equal({}, {hello: 'world'}, 'should equal');
-    t.end();
-});
-
-// output
-`
-- Expected
-+ Received
-
-- Object {}
-+ Object {
-+   "hello": "world",
-+ }
-`;
-```
-
-## License
-
-MIT
+- ✅ [`remove-newline-before-t-end`](https://github.com/coderaiser/putout/tree/master/packages/eslint-plugin-putout/lib/tape-remove-newline-before-t-end#readme)
+- ✅ [`add-newline-before-assertion`](https://github.com/coderaiser/putout/tree/master/packages/eslint-plugin-putout/lib/tape-add-newline-before-assertion#readme)
+- ✅ [`add-newline-between-tests`](https://github.com/coderaiser/putout/tree/master/packages/eslint-plugin-putout/lib/tape-add-newline-between-tests#readme)

--- a/packages/supertape/README.md
+++ b/packages/supertape/README.md
@@ -14,15 +14,18 @@
 
 [**Tape**](https://github.com/substack/tape)-inspired [`TAP`](https://testanything.org/)-compatible simplest high speed test runner with superpowers.
 
+----
+
 📼 **Supertape** is a fast, minimal test runner with the soul of **tape**. It's designed to be as compatible as possible with **tape** while still having some key improvements, such as:
 
-- the ability to work with [ESM Modules](https://nodejs.org/api/esm.html) (take a look at [mock-import](https://github.com/coderaiser/mock-import) for mocking and 🎩[ESCover](https://github.com/coderaiser/escover) for coverage)
-- a number of [built-in pretty output formatters](#formatters)
-- the ability to [extend](#testextendextensions)
+- out-of-the-box [ES6 module](https://nodejs.org/api/esm.html) support (take a look at [mock-import](https://github.com/coderaiser/mock-import) for mocking and 🎩[ESCover](https://github.com/coderaiser/escover) for coverage)
+- a number of [built-in pretty output formatters](#formatting)
+- easy [configuration](#list-of-options)
+- the ability to [extend](#extending)
 - showing colored diff when using the [`t.equal()`](#tequalresult-any-expected-any-message-string) and [`t.deepEqual()`](#tdeepequalresult-any-expected-any-message-string) assertion operators
 - detailed stack traces for `async` functions
-- multiple [`test.only`'s](#testonlyname-cb)
-- [smart timeouts](#environment-variables) for long running tests 🏃‍♂️
+- multiple [`test.only`s](#testonlymessage-string-fn-t-test--void-options-testoptions)
+- [smart timeouts](#supertape_timeout) for long running tests 🏃‍♂️
 - more natural assertions: `expected, result` -> `result, expected`:
 
   ```js
@@ -32,21 +35,64 @@
 📼 **Supertape** doesn't contain:
 
 - assertion aliases, making the available operators far more concise
-- `es3 code` and lot's of [ponyfills](https://github.com/sindresorhus/ponyfill#how-are-ponyfills-better-than-polyfills)
+- `ES3 code` and lots of [ponyfills](https://github.com/sindresorhus/ponyfill#how-are-ponyfills-better-than-polyfills)
 - `t.throws()`, `t.doesNotThrow()` - use [**tryCatch**](https://github.com/coderaiser/try-catch) or [**tryToCatch**](https://github.com/coderaiser/try-to-catch) with [`t.equal()`](#tequalresult-any-expected-any-message-string) instead
 - [`t.plan()`](https://github.com/substack/tape#tplann)
 
 For a list of all built-in assertions, see [Operators](#operators).
 
-## Install
+## Installation
 
-```
+```plain
 npm i supertape -D
 ```
 
-## Usage
+## Example
 
+```js
+// test.js
+const test = require('supertape');
+
+test('hello: world', (t) => {
+    t.pass('hello, world!');
+    t.end();
+});
 ```
+
+Output:
+
+```plain
+$ npx supertape test.js
+TAP version 13
+
+1..1
+# tests 1
+# pass 1
+
+# ✅ ok
+```
+
+## Usage and Configuration
+
+Tests can be run either through the `supertape` CLI (or optionally through `node`/`ts-node`). [Options](#list-of-options) can be specified via the command line, through environment variables, or in individual test files.
+
+### Command Line
+
+📼 **Supertape** provides a CLI that supports running both `CJS` and `ESM` tests:
+
+```sh
+$ [npx] supertape [options] [path/glob]
+```
+
+If a glob is specified instead of a single file path (e.g. `tests/*.js`), all of the test results are outputted together.
+
+#### Command Line Flags:
+
+#### `--help` (alias: `-h`)
+
+Displays a help prompt with usage information and exits:
+
+```plain
 Usage: supertape [options] [path]
 Options
    -h, --help                  display this help and exit
@@ -58,40 +104,388 @@ Options
    --no-check-duplicates       do not check messages for duplicates
 ```
 
-## Environment variables
+#### `--version` (alias: `-v`)
 
-- `SUPERTAPE_TIMEOUT` - timeout for long running processes;
-- `SUPERTAPE_CHECK_DUPLICATES` - toggle check duplicates;
-- `SUPERTAPE_CHECK_SCOPES` - check that test message has a scope: `scope: subject`;
-- `SUPERTAPE_CHECK_ASSERTIONS_COUNT` - check that assertion count is no more then 1;
-- `SUPERTAPE_CHECK_SKIPED` - check that skiped count equal to `0`, exit with status code
+Outputs version information and exits.
+
+#### `--format [format]` (alias: `-f`)
+
+Sets a specific [format](#formatting) for outputting test results. When using the CLI, this option must be set to change the format used. Defaults to `progress-bar`.
+
+#### `--require [module]` (alias: `-r`)
+
+Loads a given module before running all tests. Can be used to perform [JIT transpilation](https://github.com/substack/tape#preloading-modules).
+
+#### `--no-check-duplicates`
+
+Tells 📼 **Supertape** not to check test messages for duplicates. By default, messages are expected to be unique. (See: [Duplicate Test Messages](#duplicate-test-messages))
+
+#### `--no-check-assertions-count`
+
+Tells 📼 **Supertape** not to check the number of assertions per test. By default, only one assertion is allowed. (See: [Assertions Per Test](#assertions-per-test))
+
+#### `--no-check-scopes`
+
+Tells 📼 **Supertape** not to check test messages for proper scoping (i.e. in the form `'scope: message'`). By default, messages are expected to be scoped. (See: [Test Message Scoping](#test-message-scoping))
+
+### Environment Variables
+
+The 📼 **Supertape** CLI also supports setting some options through environment variables:
+
+```sh
+$ SUPERTAPE_TIMEOUT=5000 supertape tests/*.js
+```
+
+Certain options, such as [`SUPERTAPE_TIMEOUT`](#supertape_timeout) can only be set in this way.
+
+#### Environment Variable Only Options:
+
+#### `SUPERTAPE_TIMEOUT`
+
+Controls the time (in milliseconds) that a test is allowed to run for before timing out. By default, tests time out after 3 seconds (or `3000` ms).
+
+#### `SUPERTAPE_PROGRESS_BAR_COLOR`
+
+If using the `progress-bar` formatter, sets the color of the progress bar itself. Can either be a hex color or a valid [**chalk**](https://github.com/chalk/chalk#colors) color. Defaults to ![#f9d472](https://via.placeholder.com/15/f9d472/f9d472.png) `#f9d472`.
+
+#### `SUPERTAPE_PROGRESS_BAR_MIN`
+
+If using the `progress-bar` formatter, sets the minimum number of tests to run before showing the progress bar. Defaults to `100`. Set to `0` to always show.
+
+#### `SUPERTAPE_PROGRESS_BAR_STACK`
+
+If using the `progress-bar` formatter, sets a flag to show or hide the error stack when an assertion fails. Defaults to `1` *(show)*. Set to `0` to hide.
+
+#### Other Options:
+
+#### `SUPERTAPE_CHECK_DUPLICATES`
+
+Set to `0` to tell 📼 **Supertape** not to check test messages for duplicates. By default, messages are expected to be unique. (See: [Duplicate Test Messages](#duplicate-test-messages))
+
+#### `SUPERTAPE_CHECK_ASSERTIONS_COUNT`
+
+Set to `0` to tell 📼 **Supertape** not to check the number of assertions per test. By default, only one assertion is allowed. (See: [Assertions Per Test](#assertions-per-test))
+
+#### `SUPERTAPE_CHECK_SCOPES`
+
+Set to `0` to tell 📼 **Supertape** not to check test messages for proper scoping (i.e. in the form `'scope: message'`). By default, messages are expected to be scoped. (See: [Test Message Scoping](#test-message-scoping))
+
+### `node` and `ts-node`
+
+While the preferred way to use 📼 **Supertape** is via the CLI, any test file (`.js` or `.ts`) requiring/importing 📼 **Supertape** can be invoked through `node` or `ts-node`, respectively:
 
 ```js
-test('tape: error', (t) => {
-    t.equal(error.code, 'ENOENT');
+// test.js or test.ts
+import test from 'supertape';
+
+test('test: from (ts-)node', (t) => {
+    t.pass('hello, world!');
     t.end();
 });
 ```
 
-## 🤷 How to migrate from `tape`?
+```bash
+$ node test.js
+# OR
+$ ts-node test.ts
+```
 
-You can convert your codebase from `tape` to 📼`Supertape` with help of 🐊[`Putout`](https://github.com/coderaiser/putout), which has built-in [@putout/plugin-tape](https://github.com/coderaiser/putout/tree/master/packages/plugin-tape),
-which has a lot of rules that helps to write tests.
-Here is [result example](https://github.com/coderaiser/cloudcmd/commit/74d56f795d22e98937dce0641ee3c7514a79e9e6).
+### Formatting
 
-## `ESLint` rules
+#### Built-In Formatters
 
-[`eslint-plugin-putout`](https://github.com/coderaiser/putout/tree/master/packages/eslint-plugin-putout#readme) has rules for 📼`Supertape`:
+📼 **Supertape** provides a few different output formats beyond the regular `TAP` format. When using the [`supertape` CLI](#command-line), the `progress-bar` formatter is used by default. In all other cases, the default is the `tap` format.
 
-- ✅ [`remove-newline-before-t-end`](https://github.com/coderaiser/putout/tree/master/packages/eslint-plugin-putout/lib/tape-remove-newline-before-t-end#readme)
-- ✅ [`add-newline-before-assertion`](https://github.com/coderaiser/putout/tree/master/packages/eslint-plugin-putout/lib/tape-add-newline-before-assertion#readme)
-- ✅ [`add-newline-between-tests`](https://github.com/coderaiser/putout/tree/master/packages/eslint-plugin-putout/lib/tape-add-newline-between-tests#readme)
+The format used can be changed with:
+
+- the [`--format [format]`](#--format-format-alias--f) command line flag
+- the [`options.format`](#format-string) option passed to a test
+
+While each formatter is maintained in a separate package, they are included when downloading 📼 **Supertape**. The following is a list of such packages:
+
+|Package|Version|
+|-------|-------|
+| [`@supertape/formatter-tap`](/packages/formatter-tap)                   | [![npm][FTapNPMBadge]][FTapNPMLink]     |
+| [`@supertape/formatter-fail`](/packages/formatter-fail)                 | [![npm][FFailNPMBadge]][FFailNPMLink]   |
+| [`@supertape/formatter-progress-bar`](/packages/formatter-progress-bar) | [![npm][FProgNPMBadge]][FProgNPMLink]   |
+| [`@supertape/formatter-json-lines`](/packages/formatter-json-lines)     | [![npm][FJsonNPMBadge]][FJsonNPMLink]   |
+| [`@supertape/formatter-short`](/packages/formatter-short)               | [![npm][FShortNPMBadge]][FShortNPMLink] |
+
+[FTapNPMBadge]: https://img.shields.io/npm/v/@supertape/formatter-tap.svg?maxAge=86400
+[FTapNPMLink]: https://www.npmjs.com/package/@supertape/formatter-tap
+[FFailNPMBadge]: https://img.shields.io/npm/v/@supertape/formatter-fail.svg?maxAge=86400
+[FFailNPMLink]: https://www.npmjs.com/package/@supertape/formatter-fail
+[FProgNPMBadge]: https://img.shields.io/npm/v/@supertape/formatter-progress-bar.svg?maxAge=86400
+[FProgNPMLink]: https://www.npmjs.com/package/@supertape/formatter-progress-bar
+[FJsonNPMBadge]: https://img.shields.io/npm/v/@supertape/formatter-json-lines.svg?maxAge=86400
+[FJsonNPMLink]: https://www.npmjs.com/package/@supertape/formatter-json-lines
+[FShortNPMBadge]: https://img.shields.io/npm/v/@supertape/formatter-short.svg?maxAge=86400
+[FShortNPMLink]: https://www.npmjs.com/package/@supertape/formatter-short
+
+#### Using Other `TAP` Reporters
+
+If you'd like to use another output format instead of the built-in formatters, such as [**`tap-min`**](https://www.npmjs.com/package/tap-min), use the `format: 'tap'` option and pipe the output to the reporter of your choice:
+
+```bash
+$ supertape tests/*.js -f tap | tap-min
+```
+
+### Extending
+
+📼 **Supertape** maintains a minimal number of core assertion operators, leaving out aliases and things like `t.throws()`. Custom extension operators can either be added through the [`test.extend(extensions)`](#testextendextensions) function.
+
+The `extend()` function takes a dictionary of functions that each take an object of built-in operators as input, and return an operator function with any number of arguments. The return value of the `extend()` function is a `test` object with the custom operators added to it. For example, adding a `transform` operator:
+
+```js
+const {extend} = require('supertape');
+
+const test = extend({
+    transform: (t) => (a, b, message = 'should transform') => {
+        const {is, output} = t.equal(a + 1, b - 1);
+        return {
+            is,
+            output,
+            message,
+        };
+    },
+});
+
+test('test: transform', (t) => {
+    t.transform(1, 3);
+    t.end();
+});
+```
+
+Extension operators can also be included in the [`options.extensions`](#extensions-customoperator) object in calls to `test()`.
+
+## List of Options
+
+Individual tests can take an optional `options` parameter for setting configuration values:
+
+```js
+const test = require('supertape');
+
+test('no scope', (t) => {
+    t.pass('this test has two assertions');
+    t.pass('this test has no message scope');
+    t.end();
+}, {
+    checkAssertionsCount: false,
+    checkScopes: false,
+});
+```
+
+Instead of setting the same options multiple times, a custom wrapper can be used that sets common options:
+
+```js
+// _supertape.js
+import {test as _test} from 'supertape';
+
+export const test = (message, fn) => _test(message, fn, {
+    checkAssertionsCount: false,
+});
+```
+
+```js
+// test.js
+import test from '_supertape';
+
+test('test: wrapper', (t) => {
+    t.pass('using a wrapper');
+    t.pass('with two assetions');
+    t.end();
+});
+```
+
+### Options
+
+#### `skip: boolean`
+
+Whether or not to skip a test. Defaults to `false`.
+
+#### `only: boolean`
+
+Whether or not to mark a test as the only one run by the process. Defaults to `false`.
+
+#### `extensions: CustomOperator`
+
+Custom extension operators to use in tests. Defaults to `{}`. (See: [Extending](#extending))
+
+#### `quiet: boolean`
+
+Whether or not to not report test results. Defaults to `false`.
+
+#### `format: string`
+
+Which output format to use for the test results. The [built-in `tap` formatters](#formatting) are `tap`, `fail`, `progress-bar`, `json-lines`, and `short`. Defaults to `tap`.
+
+When using the CLI, the default formatter is `progress-bar`. This can only be overridden using the `--format [format]` flag.
+
+#### `run: boolean`
+
+Whether or not to run a test. Defaults to `true`.
+
+#### `checkDuplicates: boolean`
+
+Whether or not to check test messages for duplicates. 📼 **Supertape** expects each message to be unique. Defaults to `true`. (See: [Duplicate Test Messages](#duplicate-test-messages))
+
+#### `checkAssertionsCount: boolean`
+
+Whether or not to check the number of assertions per test. 📼 **Supertape** expects each test to have only one assertion. Defaults to `true`. (See: [Assertions Per Test](#assertions-per-test))
+
+#### `checkScopes: boolean`
+
+Whether or not to check that test messages are scoped (i.e. in the form `'scope: message'`). 📼 **Supertape** expects each test message to be scoped. (See: [Test Message Scoping](#test-message-scoping))
+
+## Validation
+
+📼 **Supertape** has a number of built-in validation checks to ensure that your tests are of the highest possible quality. A test will fail if it does not pass these checks. Certain checks can be disabled. (See: [Configuration](#usage-and-configuration))
+
+### Single Call to `t.end()`
+
+Each test must call the [`t.end()`](#tend) operator to denote that it has finished. Only one call to `t.end()` is allowed, and no assertions are allowed after it.
+
+This check cannot be disabled. In addition, 🐊 **Putout** has a rule 🐊 [`remove-useless-t-end`][PutoutTEnd] for ensuring it is only called once. (See: [Putout](#-putout))
+
+[PutoutTEnd]: https://github.com/coderaiser/putout/blob/master/packages/plugin-tape/README.md#remove-useless-t-end
+
+#### ❌ Example of Incorrect Code:
+
+```js
+test('hello: world', (t) => {
+    t.end();
+    t.end();
+    t.pass('hello, world!');
+});
+```
+
+#### ✅ Example of Correct Code:
+
+```js
+test('hello: world', (t) => {
+    t.pass('hello, world!');
+    t.end();
+});
+```
+
+### Duplicate Test Messages
+
+📼 **Supertape** expects all test messages to be unique. This check can be disabled with:
+
+- the [`--no-check-duplicates`](#--no-check-duplicates) command line flag
+- the [`SUPERTAPE_CHECK_DUPLICATES`](#supertape_check_duplicates) environment variable (set to `0`)
+- the [`checkDuplicates`](#checkduplicates-boolean) test option (set to `true`)
+
+#### ❌ Example of Incorrect Code:
+
+```js
+test('hello: world', (t) => {
+    t.pass('hello one!');
+    t.end();
+});
+
+test('hello: world', (t) => {
+    t.pass('hello two!');
+    t.end();
+});
+```
+
+### Assertions Per Test
+
+📼 **Supertape** expects that each test contains exactly one assertion. This check can be disabled with:
+
+- the [`--no-check-assertions-count`](#--no-check-assertions-count) command line flag
+- the [`SUPERTAPE_CHECK_ASSERTIONS_COUNT`](#supertape_check_assertions_count) environment variable (set to `0`)
+- the [`checkAssertionsCount`](#checkassertionscount-boolean) test option (set to `true`)
+
+#### ❌ Example of Incorrect Code:
+
+```js
+test('test: no assertion', (t) => {
+    t.end();
+});
+
+test('test: more than one assertion', (t) => {
+    t.equal(1, 1);
+    t.equal(2, 2);
+    t.end();
+});
+```
+
+#### ✅ Example of Correct Code:
+
+```js
+test('test: one', (t) => {
+    t.equal(1, 1);
+    t.end();
+});
+
+test('test: two', (t) => {
+    t.equal(2, 2);
+    t.end();
+});
+```
+
+### Test Message Scoping
+
+📼 **Supertape** expects that each test message be scoped in the form `'scope: message'`. This check can be disabled with:
+
+- the [`--no-check-scopes`](#--no-check-scopes) command line flag
+- the [`SUPERTAPE_CHECK_SCOPES`](#supertape_check_scopes) environment variable (set to `0`)
+- the [`checkScopes`](#checkscopes-boolean) test option (set to `true`)
+
+#### ❌ Example of Incorrect Code:
+
+```js
+test('test no scope', (t) => {
+    t.pass('hello, world!');
+    t.end();
+});
+```
+
+#### ✅ Example of Correct Code:
+
+```js
+test('test: scope', (t) => {
+    t.pass('hello, world!');
+    t.end();
+});
+```
+
+## API
+
+#### `test(message: string, fn: (t: Test) => void, options?: TestOptions)`
+
+The core test function. Generates a new test with a [scoped `message`](#test-message-scoping). The test object `t` provides all [built-in assertion operators](#operators) as well as any [extension operators](#extending) that have been added. Tests execute serially. By default, 📼 **Supertape** expects each test to have a [unique message](#duplicate-test-messages) and a [single assertion](#assertions-per-test):
+
+```js
+const test = require('supertape');
+
+test('hello: world', (t) => {
+    t.pass('hello, world!');
+    t.end();
+});
+```
+
+[Options](#list-of-options) can be specified on a per-test basis as well.
+
+#### `test.skip(message: string, fn: (t: Test) => void, options?: TestOptions)`
+
+Generates a new test that will be skipped over by setting [`options.skip`](#skip-boolean) to `true`.
+
+#### `test.only(message: string, fn: (t: Test) => void, options?: TestOptions)`
+
+Generates a new test that will be the only test run for the entire process, ignoring all other tests, by setting [`options.only`](#only-boolean) to `true`.
+
+#### `test.extend(extensions: CustomOperators)`
+
+Generates a new test function that includes the specified custom extension operators. For more information, see [Extending](#extending).
 
 ## Operators
 
-The assertion methods of 📼 **Supertape** are heavily influenced by [**tape**](https://github.com/substack/tape). However, to keep a minimal core of assertions, there are no aliases and some superfluous operators have been removed (such as `t.throws()`).
+The assertion operators of 📼 **Supertape** are heavily influenced by [**tape**](https://github.com/substack/tape). However, to keep a minimal core of assertions, there are no aliases and some superfluous operators have been removed (such as `t.throws()`).
 
-The following is a list of the base methods maintained by 📼 **Supertape**. Others, such as assertions for stubbing, are maintained in [special operators](#special-operators). To add custom assertion operators, see [Extending](#testextendextensions).
+The following is a list of the base methods maintained by 📼 **Supertape**. Other built-in operators, such as assertions for stubbing, are maintained in [separate packages](#other-built-in-operators). To add custom assertion operators, see [Extending](#extending).
 
 ### Core Operators
 
@@ -139,7 +533,7 @@ Generates a failing assertion with `message` as a description.
 
 #### `t.end()`
 
-Declares the end of a test explicitly. Must be called exactly once per test. (See: [Single Call to `t.end()`](#single-tend))
+Declares the end of a test explicitly. Must be called exactly once per test. (See: [Single Call to `t.end()`](#single-call-to-tend))
 
 #### `t.match(result: string, pattern: string | RegExp, message?: string)`
 
@@ -151,158 +545,36 @@ Asserts that `result` does not match the regex `pattern`. If `pattern` is not a 
 
 #### `t.comment(message: string)`
 
-Print a message without breaking the `TAP` output. Useful when using a `tap`-reporter such as `tap-colorize`, where the output is buffered and `console.log()` will print in incorrect order vis-a-vis `TAP` output.
+Prints a message without breaking the `TAP` output. Useful when using a `tap`-reporter such as `tap-colorize`, where the output is buffered and `console.log()` will print in incorrect order vis-a-vis `TAP` output.
 
-### Special Operators
+### Other Built-In Operators
 
 To simplify the core of 📼 **Supertape**, other operators are maintained in separate packages. The following is a list of all such packages:
 
-Here is a list of built-int operators:
+|Package|Version|
+|-------|-------|
+| [`@supertape/operator-stub`](/packages/operator-stub) | [![npm][OperatorStubNPMBadge]][OperatorStubNPMLink] |
 
-| Package | Version |
-|--------|-------|
-| [`@supertape/operator-stub`](/packages/operator-stub) | [![npm](https://img.shields.io/npm/v/@supertape/operator-stub.svg?maxAge=86400)](https://www.npmjs.com/package/@supertape/operator-stub) |
+[OperatorStubNPMBadge]: https://img.shields.io/npm/v/@supertape/operator-stub.svg?maxAge=86400
+[OperatorStubNPMLink]: https://www.npmjs.com/package/@supertape/operator-stub
 
-## Formatters
+## 🐊 **Putout**
 
-There is a list of built-int `formatters` to customize output:
+📼 **Supertape** goes well with 🐊 [**Putout**](https://github.com/coderaiser/putout), which has a number of rules for linting and generating high quality tests.
 
-| Package | Version |
-|--------|-------|
-| [`@supertape/formatter-tap`](/packages/formatter-tap) | [![npm](https://img.shields.io/npm/v/@supertape/formatter-tap.svg?maxAge=86400)](https://www.npmjs.com/package/@supertape/formatter-tap) |
-| [`@supertape/formatter-fail`](/packages/formatter-fail) | [![npm](https://img.shields.io/npm/v/@supertape/formatter-fail.svg?maxAge=86400)](https://www.npmjs.com/package/@supertape/formatter-fail) |
-| [`@supertape/formatter-short`](/packages/formatter-short) | [![npm](https://img.shields.io/npm/v/@supertape/formatter-short.svg?maxAge=86400)](https://www.npmjs.com/package/@supertape/formatter-short) |
-| [`@supertape/formatter-progress-bar`](/packages/formatter-progress-bar) | [![npm](https://img.shields.io/npm/v/@supertape/formatter-progress-bar.svg?maxAge=86400)](https://www.npmjs.com/package/@supertape/formatter-progress-bar) |
-| [`@supertape/formatter-json-lines`](/packages/formatter-json-lines) | [![npm](https://img.shields.io/npm/v/@supertape/formatter-json-lines.svg?maxAge=86400)](https://www.npmjs.com/package/@supertape/formatter-json-lines) |
+### Migrating From **tape**
 
-## API
+> 🐊 + 📼 = ❤️
 
-### Methods
+You can easily convert your tests from **tape** to 📼 **Supertape** using 🐊 **Putout's** built-in [`@putout/plugin-tape`][PutoutPluginTape]. For a conversion example, check out [this output][PutoutExample].
 
-The assertion methods in `supertape` are heavily influenced by [tape](https://github.com/substack/tape).
+[PutoutPluginTape]: https://github.com/coderaiser/putout/tree/master/packages/plugin-tape#readme
+[PutoutExample]: https://github.com/coderaiser/cloudcmd/commit/74d56f795d22e98937dce0641ee3c7514a79e9e6
 
-```js
-const test = require('supertape');
-const {sum} = require('./calc.js');
+### **ESLint** Rules
 
-test('calc: sum', (t) => {
-    const result = sum(1, 2);
-    const expected = 3;
-    
-    t.equal(result, expected);
-    t.end();
-});
-```
+🐊 **Putout** also provides some **ESLint** rules for 📼 **Supertape** to help ensure high quality tests:
 
-or in `ESM`:
-
-```js
-import {test} from 'supertape';
-import {sum} from './calc.js';
-
-test('calc: sum', (t) => {
-    const result = sum(1, 2);
-    const expected = 3;
-    
-    t.equal(result, expected);
-    t.end();
-});
-```
-
-## test(name, cb)
-
-Create a new test with `name` string.
-`cb(t)` fires with the new test object `t` once all preceding tests have
-finished. Tests execute serially.
-
-## test.only(name, cb)
-
-Like `test(name, cb)` except if you use `.only` this is the only test case
-that will run for the entire process, all other test cases using `tape` will
-be ignored.
-
-## test.skip(name, cb)
-
-Generate a new test that will be skipped over.
-
-## test.extend(extensions)
-
-Extend base assertions with more:
-
-```js
-const {extend} = require('supertape');
-const test = extend({
-    transform: (operator) => (a, b, message = 'should transform') => {
-        const {is, output} = operator.equal(a + 1, b - 1);
-        return {
-            is,
-            output,
-        };
-    },
-});
-
-test('assertion', (t) => {
-    t.transform(1, 3);
-    t.end();
-});
-```
-
-## Example
-
-```js
-const test = require('supertape');
-
-test('lib: arguments', async (t) => {
-    throw Error('hello');
-    // will call t.fail with an error
-    // will call t.end
-});
-
-test('lib: diff', (t) => {
-    t.equal({}, {hello: 'world'}, 'should equal');
-    t.end();
-});
-
-// output
-`
-- Expected
-+ Received
-
-- Object {}
-+ Object {
-+   "hello": "world",
-+ }
-`;
-```
-
-## 🚪Exit Codes
-
-📼**Supertape** can have one of next [exit codes](https://github.com/coderaiser/supertape/blob/master/packages/supertape/lib/exit-codes.js):
-
-| Code | Name | Description |
-|------|------|-----------------|
-| 0    | `OK` | no errors found |
-| 1    | `FAIL` | test failed |
-| 2    | `WAS_STOP` | test was halted by user |
-| 3    | `UNHANDLED`| unhandled exception occurred |
-| 4    | `INVALID_OPTION`| wrong option provided |
-| 5    | `SKIPED` | works only with `SUPERTAPE_CHECK_SKIPED` env variable when skiped files 1 and more |
-
-Here is how exit code can look like:
-
-```js
-import {SKIPED} from 'supertape/exit-codes';
-
-const env = {
-    ESCOVER_SUCCESS_EXIT_CODE: SKIPED,
-    SUPERTAPE_CHECK_SKIPED: 1,
-};
-
-export default {
-    test: () => [env, `escover tape 'test/**/*.js' 'lib/**/*.spec.js'`],
-};
-```
-
-## License
-
-MIT
+- ✅ [`remove-newline-before-t-end`](https://github.com/coderaiser/putout/tree/master/packages/eslint-plugin-putout/lib/tape-remove-newline-before-t-end#readme)
+- ✅ [`add-newline-before-assertion`](https://github.com/coderaiser/putout/tree/master/packages/eslint-plugin-putout/lib/tape-add-newline-before-assertion#readme)
+- ✅ [`add-newline-between-tests`](https://github.com/coderaiser/putout/tree/master/packages/eslint-plugin-putout/lib/tape-add-newline-between-tests#readme)

--- a/packages/supertape/README.md
+++ b/packages/supertape/README.md
@@ -144,6 +144,12 @@ Certain options, such as [`SUPERTAPE_TIMEOUT`](#supertape_timeout) can only be s
 
 Controls the time (in milliseconds) that a test is allowed to run for before timing out. By default, tests time out after 3 seconds (or `3000` ms).
 
+#### `SUPERTAPE_CHECK_SKIPED`
+
+If specified, tells 📼 **Supertape** to check the number of skipped test files. Exits with status code [`SKIPED`](#-exit-codes).
+
+*Note: yes, `skiped` is a typo.*
+
 #### `SUPERTAPE_PROGRESS_BAR_COLOR`
 
 If using the `progress-bar` formatter, sets the color of the progress bar itself. Can either be a hex color or a valid [**chalk**](https://github.com/chalk/chalk#colors) color. Defaults to ![#f9d472](https://via.placeholder.com/15/f9d472/f9d472.png) `#f9d472`.
@@ -557,6 +563,32 @@ To simplify the core of 📼 **Supertape**, other operators are maintained in se
 
 [OperatorStubNPMBadge]: https://img.shields.io/npm/v/@supertape/operator-stub.svg?maxAge=86400
 [OperatorStubNPMLink]: https://www.npmjs.com/package/@supertape/operator-stub
+
+## 🚪 Exit Codes
+
+📼**Supertape** can have one of the following [exit codes](https://github.com/coderaiser/supertape/blob/master/packages/supertape/lib/exit-codes.js) to denote its status:
+
+| Code | Name | Description |
+|------|------|-----------------|
+| 0    | `OK` | no errors found |
+| 1    | `FAIL` | test failed |
+| 2    | `WAS_STOP` | test was halted by user |
+| 3    | `UNHANDLED`| unhandled exception occurred |
+| 4    | `INVALID_OPTION`| wrong option provided |
+| 5    | `SKIPED` | works only with [`SUPERTAPE_CHECK_SKIPED`](#supertape_check_skiped) when skiped files 1 and more |
+
+```js
+import {SKIPED} from 'supertape/exit-codes';
+
+const env = {
+    ESCOVER_SUCCESS_EXIT_CODE: SKIPED,
+    SUPERTAPE_CHECK_SKIPED: 1,
+};
+
+export default {
+    test: () => [env, `escover tape 'test/**/*.js' 'lib/**/*.spec.js'`],
+};
+```
 
 ## 🐊 **Putout**
 

--- a/packages/supertape/lib/supertape.d.ts
+++ b/packages/supertape/lib/supertape.d.ts
@@ -33,9 +33,15 @@ type Test = Operator & OperatorStub & {
 };
 
 type TestOptions = {
-    checkAssertionsCount?: boolean,
-    checkScopes?: boolean,
-    checkDuplicates?: boolean,
+    skip?: boolean;
+    only?: boolean;
+    extensions?: CustomOperator;
+    quiet?: boolean;
+    format?: string;
+    run?: boolean;
+    checkDuplicates?: boolean;
+    checkAssertionsCount?: boolean;
+    checkScopes?: boolean;
 };
 
 declare function test(message: string, fn: (t: Test) => void, options?: TestOptions): void;


### PR DESCRIPTION
README changes from #3. I kept out the things you said were internal and have left out references to using TypeScript (pending #5 and me opening a PR for [types](https://github.com/tommy-mitchell/supertape/tree/pr/types)). Fixes some typos and improves the structure compared to [before](https://github.com/tommy-mitchell/supertape).