### PR TITLE
Add per-test timeout option

### DIFF
--- a/packages/supertape/lib/run-tests.js
+++ b/packages/supertape/lib/run-tests.js
@@ -15,10 +15,9 @@ const notSkip = ({skip}) => !skip;
 
 const getInitOperators = async () => await import('./operators.mjs');
 
-const {SUPERTAPE_TIMEOUT = 3000} = process.env;
 const DEBUG_TIME = 3000 * 1000;
 
-const timeout = (time, value) => {
+const doTimeout = (time, value) => {
     let stop;
     
     if (isDebug)
@@ -95,6 +94,7 @@ async function runTests(tests, {formatter, operators, skiped, isStop}) {
             incPassed,
             getValidationMessage,
             validations,
+            timeout,
             
             extensions: {
                 ...operators,
@@ -118,7 +118,7 @@ async function runTests(tests, {formatter, operators, skiped, isStop}) {
     };
 }
 
-async function runOneTest({message, at, fn, extensions, formatter, count, total, failed, incCount, incPassed, incFailed, getValidationMessage, validations}) {
+async function runOneTest({message, at, fn, extensions, formatter, count, total, failed, incCount, incPassed, incFailed, getValidationMessage, validations, timeout}) {
     const isReturn = fullstore(false);
     const assertionsCount = fullstore(0);
     const isEnded = fullstore(false);
@@ -145,7 +145,7 @@ async function runOneTest({message, at, fn, extensions, formatter, count, total,
     });
     
     if (!isReturn()) {
-        const [timer, stopTimer] = timeout(SUPERTAPE_TIMEOUT, ['timeout']);
+        const [timer, stopTimer] = doTimeout(timeout, ['timeout']);
         const [error] = await Promise.race([tryToCatch(fn, t), timer]);
         
         stopTimer();

--- a/packages/supertape/lib/supertape.d.ts
+++ b/packages/supertape/lib/supertape.d.ts
@@ -34,6 +34,7 @@ type TestOptions = {
     checkAssertionsCount?: boolean;
     checkScopes?: boolean;
     checkDuplicates?: boolean;
+    timeout?: number;
 };
 
 declare function test(message: string, fn: (t: Test) => void, options?: TestOptions): void;

--- a/packages/supertape/lib/supertape.js
+++ b/packages/supertape/lib/supertape.js
@@ -44,13 +44,14 @@ const defaultOptions = {
     checkIfEnded: true,
     checkAssertionsCount: true,
     checkScopes: true,
+    timeout: process.env.SUPERTAPE_TIMEOUT || 3000
 };
 
 function _createEmitter({quiet, stream = stdout, format, getOperators, isStop, readyFormatter, workerFormatter}) {
     const tests = [];
     const emitter = new EventEmitter();
     
-    emitter.on('test', (message, fn, {skip, only, extensions, at, validations}) => {
+    emitter.on('test', (message, fn, {skip, only, extensions, at, validations, timeout}) => {
         tests.push({
             message,
             fn,
@@ -59,6 +60,7 @@ function _createEmitter({quiet, stream = stdout, format, getOperators, isStop, r
             extensions,
             at,
             validations,
+            timeout,
         });
     });
     
@@ -154,6 +156,7 @@ function test(message, fn, options = {}) {
         checkAssertionsCount,
         checkIfEnded,
         workerFormatter,
+        timeout
     } = {
         ...defaultOptions,
         ...initedOptions,
@@ -186,6 +189,7 @@ function test(message, fn, options = {}) {
         extensions,
         at,
         validations,
+        timeout,
     });
     
     if (run)


### PR DESCRIPTION
Now each test can have its own timeout option, like this:

```js
test("long test", t => {
  t.equal(longCalculation(), 42)
}, {timeout: 60000})
```

This is useful when most tests are quick and some are slow.

If there's no `timeout` option, the SUPERTAPE_TIMEOUT environment variable takes effect. This defaults to 3000ms like before.

This change is backwards compatible with previous supertape versions.