### PR TITLE
Remove dependency on deep-equal

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,17 +241,17 @@ Asserts that `result` and `expected` are not strictly equal. If `message` is pro
 
 #### `t.deepEqual(result: any, expected: any, message?: string)`
 
-Asserts that `result` and `expected` are loosely equal, with the same structure and nested values. If `message` is provided, it will be outputted as a description of the assertion.
+Asserts that `result` and `expected` are equal, with the same structure and nested values. If `message` is provided, it will be outputted as a description of the assertion.
 
-☝️ *Note: uses [node's deepEqual() algorithm][NodeDeepEqual] with strict comparisons (`===`) on leaf nodes*
+☝️ *Note: uses [node's isDeepStrictEqual() algorithm][NodeDeepEqual] with strict comparisons (`===`) on leaf nodes*
 
 #### `t.notDeepEqual(result: any, expected: any, message?: string)`
 
-Asserts that `result` and `expected` not loosely equal, with different structure and/or nested values. If `message` is provided, it will be outputted as a description of the assertion.
+Asserts that `result` and `expected` are not equal, with different structure and/or nested values. If `message` is provided, it will be outputted as a description of the assertion.
 
-☝️ *Note: uses [node's deepEqual() algorithm][NodeDeepEqual] with strict comparisons (`===`) on leaf nodes*
+☝️ *Note: uses [node's isDeepStrictEqual() algorithm][NodeDeepEqual] with strict comparisons (`===`) on leaf nodes*
 
-[NodeDeepEqual]: https://github.com/substack/node-deep-equal
+[NodeDeepEqual]: https://nodejs.org/dist/latest-v17.x/docs/api/util.html#utilisdeepstrictequalval1-val2
 
 #### `t.ok(result: boolean | any, message?: string)`
 

--- a/packages/supertape/lib/operators.mjs
+++ b/packages/supertape/lib/operators.mjs
@@ -1,4 +1,4 @@
-import { isDeepStrictEqual } from 'node:util';
+import {isDeepStrictEqual} from 'node:util';
 import diff from './diff.mjs';
 import {
     formatOutput,

--- a/packages/supertape/lib/operators.mjs
+++ b/packages/supertape/lib/operators.mjs
@@ -1,4 +1,4 @@
-import deepEqualCheck from 'deep-equal';
+import { isDeepStrictEqual } from 'node:util';
 import diff from './diff.mjs';
 import {
     formatOutput,
@@ -119,7 +119,7 @@ const fail = (error, at) => ({
 });
 
 const deepEqual = (result, expected, message = 'should deep equal') => {
-    const is = deepEqualCheck(result, expected);
+    const is = isDeepStrictEqual(result, expected);
     const output = is ? '' : diff(expected, result);
     
     return {
@@ -132,7 +132,7 @@ const deepEqual = (result, expected, message = 'should deep equal') => {
 };
 
 const notDeepEqual = (result, expected, message = 'should not deep equal') => {
-    const is = !deepEqualCheck(result, expected);
+    const is = !isDeepStrictEqual(result, expected);
     const output = is ? '' : diff(expected, result);
     
     return {

--- a/packages/supertape/package.json
+++ b/packages/supertape/package.json
@@ -51,7 +51,6 @@
     "@supertape/formatter-time": "^1.0.0",
     "@supertape/operator-stub": "^3.0.0",
     "cli-progress": "^3.8.2",
-    "deep-equal": "^2.0.3",
     "fullstore": "^3.0.0",
     "glob": "^10.3.10",
     "jest-diff": "^29.0.1",


### PR DESCRIPTION
node.js has a built-in `util.isDeepStrictEqual` since v9.0.0: https://nodejs.org/docs/latest-v21.x/api/assert.html#assertdeepstrictequalactual-expected-message

This is helpful because the `deep-equal` package has 50 dependencies, mostly ponyfills. We can make supertape have 34% fewer dependencies and 18% less installed filesize just by using the built in function instead of the `deep-equal` package.

However, this change makes it go from a loosely equal comparison to a strictly equal comparison, which could affect people's tests. (I had to fix one of mine that was expecting `null` but actually got `undefined`.) So a major version bump to v11 will be required.